### PR TITLE
Integration of features for EEMBC power analysis.

### DIFF
--- a/hls4ml/templates/vivado_accelerator/arty-a7-100t/c_drivers/sdk/common/main.c
+++ b/hls4ml/templates/vivado_accelerator/arty-a7-100t/c_drivers/sdk/common/main.c
@@ -19,6 +19,24 @@
 
 #include "data.h"
 
+#define EEMBC_POWER 1
+
+#ifdef EEMBC_POWER
+#include "xgpio.h"       /* AXI GPIO drivers */
+
+#define PIN 0x01
+#define GPIO_PMOD_PIN_DEVICE_ID  XPAR_GPIO_0_DEVICE_ID
+
+#define set_pin_high(InstancePtr, Mask) \
+        XGpio_DiscreteWrite(InstancePtr, 1, Mask)
+
+#define set_pin_low(InstancePtr, Mask) \
+        XGpio_DiscreteClear(InstancePtr, 1, Mask)
+
+XGpio Gpio;
+#endif
+
+
 //#define __DEBUG__
 
 #define MAX_PRINT_ELEMENTS (16)
@@ -297,6 +315,33 @@ int main(int argc, char** argv) {
 #endif
 
     PRINTF("INFO: ==================================================\r\n");
+
+
+#ifdef EEMBC_POWER
+    /* Initialize the GPIO driver */
+	status = XGpio_Initialize(&Gpio, GPIO_PMOD_PIN_DEVICE_ID);
+	if (status != XST_SUCCESS) {
+		xil_printf("GPIO Initialization Failed\r\n");
+		return XST_FAILURE;
+	}
+
+	set_pin_low(&Gpio, PIN);
+
+    PRINTF("INFO: Connect logic analyzer to the pin 3 of Pmod D\r\n");
+    PRINTF("INFO: Press any key to start:\r\n");
+    dummy = inbyte();
+
+	/* Loop forever */
+	for (unsigned i; i < 100; i++) {
+		set_pin_high(&Gpio, PIN);
+
+        sleep(1);
+
+		set_pin_low(&Gpio, PIN);
+
+        sleep(1);
+	}
+#endif
 
     cleanup_platform();
 

--- a/hls4ml/templates/vivado_accelerator/arty-a7-100t/verilog_wrappers/design_1_wrapper.v
+++ b/hls4ml/templates/vivado_accelerator/arty-a7-100t/verilog_wrappers/design_1_wrapper.v
@@ -1,0 +1,197 @@
+`timescale 1 ps / 1 ps
+
+`define EEMBC_POWER 1
+
+module design_1_wrapper
+   (ddr3_sdram_addr,
+    ddr3_sdram_ba,
+    ddr3_sdram_cas_n,
+    ddr3_sdram_ck_n,
+    ddr3_sdram_ck_p,
+    ddr3_sdram_cke,
+    ddr3_sdram_cs_n,
+    ddr3_sdram_dm,
+    ddr3_sdram_dq,
+    ddr3_sdram_dqs_n,
+    ddr3_sdram_dqs_p,
+    ddr3_sdram_odt,
+    ddr3_sdram_ras_n,
+    ddr3_sdram_reset_n,
+    ddr3_sdram_we_n
+`ifdef EEMBC_POWER
+    ,
+    qspi_flash_io0_io,
+    qspi_flash_io1_io,
+    qspi_flash_io2_io,
+    qspi_flash_io3_io,
+    qspi_flash_sck_io,
+    qspi_flash_ss_io
+ `endif
+    ,
+    reset,
+    sys_clock
+`ifdef EEMBC_POWER
+    ,
+    pmod_uart_rxd,
+    pmod_uart_txd,
+    pmod_pin
+`endif
+    );
+  output [13:0]ddr3_sdram_addr;
+  output [2:0]ddr3_sdram_ba;
+  output ddr3_sdram_cas_n;
+  output [0:0]ddr3_sdram_ck_n;
+  output [0:0]ddr3_sdram_ck_p;
+  output [0:0]ddr3_sdram_cke;
+  output [0:0]ddr3_sdram_cs_n;
+  output [1:0]ddr3_sdram_dm;
+  inout [15:0]ddr3_sdram_dq;
+  inout [1:0]ddr3_sdram_dqs_n;
+  inout [1:0]ddr3_sdram_dqs_p;
+  output [0:0]ddr3_sdram_odt;
+  output ddr3_sdram_ras_n;
+  output ddr3_sdram_reset_n;
+  output ddr3_sdram_we_n;
+`ifdef EEMBC_POWER
+  inout qspi_flash_io0_io;
+  inout qspi_flash_io1_io;
+  inout qspi_flash_io2_io;
+  inout qspi_flash_io3_io;
+  inout qspi_flash_sck_io;
+  inout qspi_flash_ss_io;
+ `endif
+  input reset;
+  input sys_clock;
+`ifdef EEMBC_POWER
+  input pmod_uart_rxd;
+  output pmod_uart_txd;
+  output pmod_pin;
+`endif
+
+
+  wire [13:0]ddr3_sdram_addr;
+  wire [2:0]ddr3_sdram_ba;
+  wire ddr3_sdram_cas_n;
+  wire [0:0]ddr3_sdram_ck_n;
+  wire [0:0]ddr3_sdram_ck_p;
+  wire [0:0]ddr3_sdram_cke;
+  wire [0:0]ddr3_sdram_cs_n;
+  wire [1:0]ddr3_sdram_dm;
+  wire [15:0]ddr3_sdram_dq;
+  wire [1:0]ddr3_sdram_dqs_n;
+  wire [1:0]ddr3_sdram_dqs_p;
+  wire [0:0]ddr3_sdram_odt;
+  wire ddr3_sdram_ras_n;
+  wire ddr3_sdram_reset_n;
+  wire ddr3_sdram_we_n;
+`ifdef EEMBC_POWER
+  wire qspi_flash_io0_i;
+  wire qspi_flash_io0_io;
+  wire qspi_flash_io0_o;
+  wire qspi_flash_io0_t;
+  wire qspi_flash_io1_i;
+  wire qspi_flash_io1_io;
+  wire qspi_flash_io1_o;
+  wire qspi_flash_io1_t;
+  wire qspi_flash_io2_i;
+  wire qspi_flash_io2_io;
+  wire qspi_flash_io2_o;
+  wire qspi_flash_io2_t;
+  wire qspi_flash_io3_i;
+  wire qspi_flash_io3_io;
+  wire qspi_flash_io3_o;
+  wire qspi_flash_io3_t;
+  wire qspi_flash_sck_i;
+  wire qspi_flash_sck_io;
+  wire qspi_flash_sck_o;
+  wire qspi_flash_sck_t;
+  wire qspi_flash_ss_i;
+  wire qspi_flash_ss_io;
+  wire qspi_flash_ss_o;
+  wire qspi_flash_ss_t;
+`endif
+  wire reset;
+  wire sys_clock;
+
+`ifdef EEMBC_POWER
+  IOBUF qspi_flash_io0_iobuf
+       (.I(qspi_flash_io0_o),
+        .IO(qspi_flash_io0_io),
+        .O(qspi_flash_io0_i),
+        .T(qspi_flash_io0_t));
+  IOBUF qspi_flash_io1_iobuf
+       (.I(qspi_flash_io1_o),
+        .IO(qspi_flash_io1_io),
+        .O(qspi_flash_io1_i),
+        .T(qspi_flash_io1_t));
+  IOBUF qspi_flash_io2_iobuf
+       (.I(qspi_flash_io2_o),
+        .IO(qspi_flash_io2_io),
+        .O(qspi_flash_io2_i),
+        .T(qspi_flash_io2_t));
+  IOBUF qspi_flash_io3_iobuf
+       (.I(qspi_flash_io3_o),
+        .IO(qspi_flash_io3_io),
+        .O(qspi_flash_io3_i),
+        .T(qspi_flash_io3_t));
+  IOBUF qspi_flash_sck_iobuf
+       (.I(qspi_flash_sck_o),
+        .IO(qspi_flash_sck_io),
+        .O(qspi_flash_sck_i),
+        .T(qspi_flash_sck_t));
+  IOBUF qspi_flash_ss_iobuf
+       (.I(qspi_flash_ss_o),
+        .IO(qspi_flash_ss_io),
+        .O(qspi_flash_ss_i),
+        .T(qspi_flash_ss_t));
+`endif
+
+  design_1 design_1_i
+       (.ddr3_sdram_addr(ddr3_sdram_addr),
+        .ddr3_sdram_ba(ddr3_sdram_ba),
+        .ddr3_sdram_cas_n(ddr3_sdram_cas_n),
+        .ddr3_sdram_ck_n(ddr3_sdram_ck_n),
+        .ddr3_sdram_ck_p(ddr3_sdram_ck_p),
+        .ddr3_sdram_cke(ddr3_sdram_cke),
+        .ddr3_sdram_cs_n(ddr3_sdram_cs_n),
+        .ddr3_sdram_dm(ddr3_sdram_dm),
+        .ddr3_sdram_dq(ddr3_sdram_dq),
+        .ddr3_sdram_dqs_n(ddr3_sdram_dqs_n),
+        .ddr3_sdram_dqs_p(ddr3_sdram_dqs_p),
+        .ddr3_sdram_odt(ddr3_sdram_odt),
+        .ddr3_sdram_ras_n(ddr3_sdram_ras_n),
+        .ddr3_sdram_reset_n(ddr3_sdram_reset_n),
+        .ddr3_sdram_we_n(ddr3_sdram_we_n)
+`ifdef EEMBC_POWER
+        ,
+        .qspi_flash_io0_i(qspi_flash_io0_i),
+        .qspi_flash_io0_o(qspi_flash_io0_o),
+        .qspi_flash_io0_t(qspi_flash_io0_t),
+        .qspi_flash_io1_i(qspi_flash_io1_i),
+        .qspi_flash_io1_o(qspi_flash_io1_o),
+        .qspi_flash_io1_t(qspi_flash_io1_t),
+        .qspi_flash_io2_i(qspi_flash_io2_i),
+        .qspi_flash_io2_o(qspi_flash_io2_o),
+        .qspi_flash_io2_t(qspi_flash_io2_t),
+        .qspi_flash_io3_i(qspi_flash_io3_i),
+        .qspi_flash_io3_o(qspi_flash_io3_o),
+        .qspi_flash_io3_t(qspi_flash_io3_t),
+        .qspi_flash_sck_i(qspi_flash_sck_i),
+        .qspi_flash_sck_o(qspi_flash_sck_o),
+        .qspi_flash_sck_t(qspi_flash_sck_t),
+        .qspi_flash_ss_i(qspi_flash_ss_i),
+        .qspi_flash_ss_o(qspi_flash_ss_o),
+        .qspi_flash_ss_t(qspi_flash_ss_t)
+ `endif
+        ,
+        .reset(reset),
+        .sys_clock(sys_clock)
+`ifdef EEMBC_POWER
+        ,
+        .pmod_uart_rxd(pmod_uart_rxd),
+        .pmod_uart_txd(pmod_uart_txd),
+        .pmod_pin(pmod_pin)
+`endif
+
+        );
+endmodule

--- a/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/pin_pmod.xdc
+++ b/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/pin_pmod.xdc
@@ -1,0 +1,4 @@
+# AXI GPIO controlled pin on Pmod Header JD
+
+# Output pin, PMOD D pin 3 (JD4), IO_L13N_T2_MRCC_35, F4, Blue cable
+set_property -dict { PACKAGE_PIN F4 IOSTANDARD LVCMOS33 } [get_ports { pmod_pin }];

--- a/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/qspi.xdc
+++ b/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/qspi.xdc
@@ -1,0 +1,13 @@
+#
+# See also
+# https://github.com/Digilent/digilent-xdc/blob/master/Arty-A7-100-Master.xdc
+#
+
+set_property BITSTREAM.GENERAL.COMPRESS TRUE [current_design]
+
+# Quad SPI Flash
+set_property -dict { PACKAGE_PIN L13   IOSTANDARD LVCMOS33 } [get_ports { qspi_flash_ss_io }]; #IO_L6P_T0_FCS_B_14 Sch=qspi_cs
+set_property -dict { PACKAGE_PIN K17   IOSTANDARD LVCMOS33 } [get_ports { qspi_flash_io0_io }]; #IO_L1P_T0_D00_MOSI_14 Sch=qspi_dq[0]
+set_property -dict { PACKAGE_PIN K18   IOSTANDARD LVCMOS33 } [get_ports { qspi_flash_io1_io }]; #IO_L1N_T0_D01_DIN_14 Sch=qspi_dq[1]
+set_property -dict { PACKAGE_PIN L14   IOSTANDARD LVCMOS33 } [get_ports { qspi_flash_io2_io }]; #IO_L2P_T0_D02_14 Sch=qspi_dq[2]
+set_property -dict { PACKAGE_PIN M14   IOSTANDARD LVCMOS33 } [get_ports { qspi_flash_io3_io }]; #IO_L2N_T0_D03_14 Sch=qspi_dq[3]

--- a/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/uart_pmod.xdc
+++ b/hls4ml/templates/vivado_accelerator/arty-a7-100t/xdc_constraints/uart_pmod.xdc
@@ -1,0 +1,8 @@
+# Expose UART Interface on Pmod Header JA
+# You may need https://www.sparkfun.com/products/9873
+
+# RX uart, PMOD A pin 2 (JA2), IO_L4P_T0_15, B11, BROWN cable
+set_property -dict { PACKAGE_PIN B11 IOSTANDARD LVCMOS33 } [get_ports { pmod_uart_rxd }];
+
+# TX uart, PMOD A pin 3 (JA3), IO_L4N_T0_15, A11, RED cable
+set_property -dict { PACKAGE_PIN A11 IOSTANDARD LVCMOS33 } [get_ports { pmod_uart_txd }];

--- a/hls4ml/templates/vivado_accelerator_config.py
+++ b/hls4ml/templates/vivado_accelerator_config.py
@@ -14,7 +14,7 @@ class VivadoAcceleratorConfig(object):
             self.part = board_info['part']
         else:
             raise Exception('The board does not appear in supported_boards.json file')
-        
+
         if self.config.get('XilinxPart') is not None:
             if self.config.get('XilinxPart') != self.part:
                 print('WARNING: You set a XilinxPart that does not correspond to the Board you specified. The correct '
@@ -29,7 +29,7 @@ class VivadoAcceleratorConfig(object):
                 if prec.get('Input') is None or prec.get('Output') is None:
                     raise Exception('Input and Output fields must be provided in the AcceleratorConfig->Precision')
         else:
-            accel_config = {'Precision': 
+            accel_config = {'Precision':
                                 {
                                     'Input': 'float',
                                     'Output': 'float'
@@ -122,11 +122,17 @@ class VivadoAcceleratorConfig(object):
         return '../templates/vivado_accelerator/' + self.board + '/' + self.driver + '_drivers/' + \
                self.get_driver_files()
 
+    def get_vivado_ip_wrapper_path(self):
+        return '../templates/vivado_accelerator/' + self.board + '/verilog_wrappers'
+
+    def get_vivado_constratins_path(self):
+        return '../templates/vivado_accelerator/' + self.board + '/xdc_constraints'
+
     def get_driver_files(self):
         if self.driver == 'c':
             driver_dir = 'sdk'
             return driver_dir
-        elif self.driver == 'python': 
+        elif self.driver == 'python':
             driver_ext = '.py'
             return self.interface + '_driver' + driver_ext
 

--- a/hls4ml/templates/vivado_accelerator_config.py
+++ b/hls4ml/templates/vivado_accelerator_config.py
@@ -125,7 +125,7 @@ class VivadoAcceleratorConfig(object):
     def get_vivado_ip_wrapper_path(self):
         return '../templates/vivado_accelerator/' + self.board + '/verilog_wrappers'
 
-    def get_vivado_constratins_path(self):
+    def get_vivado_constraints_path(self):
         return '../templates/vivado_accelerator/' + self.board + '/xdc_constraints'
 
     def get_driver_files(self):

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -333,6 +333,13 @@ class VivadoAcceleratorWriter(VivadoWriter):
         filedir = os.path.dirname(os.path.abspath(__file__))
         copyfile(os.path.join(filedir, self.vivado_accelerator_config.get_tcl_file_path()),
                  '{}/design.tcl'.format(model.config.get_output_dir()))
+        if self.vivado_accelerator_config.get_interface() == 'axi_master':
+            copytree(os.path.join(filedir, self.vivado_accelerator_config.get_vivado_ip_wrapper_path()),
+                     '{}/'.format(model.config.get_output_dir()),
+                     dirs_exist_ok=True)
+            copytree(os.path.join(filedir, self.vivado_accelerator_config.get_vivado_constratins_path()),
+                     '{}/'.format(model.config.get_output_dir()),
+                     dirs_exist_ok=True)
         f = open('{}/project.tcl'.format(model.config.get_output_dir()), 'w')
         f.write('variable myproject\n')
         f.write('set myproject "{}"\n'.format(model.config.get_project_name()))

--- a/hls4ml/writer/vivado_accelerator_writer.py
+++ b/hls4ml/writer/vivado_accelerator_writer.py
@@ -333,11 +333,11 @@ class VivadoAcceleratorWriter(VivadoWriter):
         filedir = os.path.dirname(os.path.abspath(__file__))
         copyfile(os.path.join(filedir, self.vivado_accelerator_config.get_tcl_file_path()),
                  '{}/design.tcl'.format(model.config.get_output_dir()))
-        if self.vivado_accelerator_config.get_interface() == 'axi_master':
+        if self.vivado_accelerator_config.get_interface() == 'axi_master' and self.vivado_accelerator_config.board == "arty-a7-100t":
             copytree(os.path.join(filedir, self.vivado_accelerator_config.get_vivado_ip_wrapper_path()),
                      '{}/'.format(model.config.get_output_dir()),
                      dirs_exist_ok=True)
-            copytree(os.path.join(filedir, self.vivado_accelerator_config.get_vivado_constratins_path()),
+            copytree(os.path.join(filedir, self.vivado_accelerator_config.get_vivado_constraints_path()),
                      '{}/'.format(model.config.get_output_dir()),
                      dirs_exist_ok=True)
         f = open('{}/project.tcl'.format(model.config.get_output_dir()), 'w')


### PR DESCRIPTION
For ARTY-A7 100T only.

- disable UART over USB and use UART over Pmod A (pin 2 TX, pin 3 RX --
from the breakboard perspective)
- add AXI GPIO controlled pin on Pmod D (pin 3)
- enable QSPI IPs

Attention: QSPI programming is not scripted, please follow the
instructions at:
https://digilent.com/reference/learn/programmable-logic/tutorials/htsspisf/start#sdk_steps_to_create_a_bootloader_and_program_the_board